### PR TITLE
temporary_redirects.map: add redirects for format file version 32

### DIFF
--- a/temporary_redirects.map
+++ b/temporary_redirects.map
@@ -1,2 +1,4 @@
 "/default_bundle.tar" "https://data1.fullyjustified.net/tlextras-2020.0r0.tar";
 "/default_bundle.tar.index.gz" "https://data1.fullyjustified.net/tlextras-2020.0r0.tar.index.gz";
+"/default_bundle_v32.tar" "https://data1.fullyjustified.net/tlextras-2021.3r0.tar";
+"/default_bundle_v32.tar.index.gz" "https://data1.fullyjustified.net/tlextras-2021.3r0.tar.index.gz";


### PR DESCRIPTION
This is the version associated with TeXLive 2021.